### PR TITLE
Spring Cleaning: Tossing out .class, .log files, and that embarrassing VM crash log collection (hs_err_pid)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 target/
 logs/
 *.log
+*.class
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
Tossing out .class, .log files, and that embarrassing VM crash log collection (hs_err_pid)